### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The script uses sudo internally when self-updating and when making the links */l
 
 Dependencies
 ```text
-sudo apt install git bc bison flex libssl-dev
+sudo apt install git bc bison flex libssl-dev python2
 ```
 
 Install


### PR DESCRIPTION
Python2 seems to be a prerequisite now.
The script otherwise complayns about 'env: python2' not exixting.